### PR TITLE
💄 feat(docs): tevm.sh theme, hero, logo assets and an opcode stepper

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -2,3 +2,4 @@ dist/
 .vocs/
 .vercel/
 node_modules/
+src/pages.gen.ts

--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32" role="img" aria-label="Guillotine Mini">
+  <rect width="32" height="32" rx="7" fill="#0085ff"/>
+  <!-- guillotine frame -->
+  <path d="M8 6.5v19M24 6.5v19" stroke="#ffffff" stroke-opacity="0.55" stroke-width="2" stroke-linecap="round"/>
+  <!-- angled blade -->
+  <path d="M8 9h16l-4 7H8z" fill="#ffffff"/>
+  <path d="M8 20h16" stroke="#ffffff" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/docs/public/logo-dark.svg
+++ b/docs/public/logo-dark.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 40" width="240" height="40" role="img" aria-label="Guillotine Mini">
+  <g>
+    <rect x="0" y="4" width="32" height="32" rx="7" fill="#4da6ff"/>
+    <path d="M8 10.5v19M24 10.5v19" stroke="#0b0e14" stroke-opacity="0.55" stroke-width="2" stroke-linecap="round"/>
+    <path d="M8 13h16l-4 7H8z" fill="#0b0e14"/>
+    <path d="M8 24h16" stroke="#0b0e14" stroke-width="2" stroke-linecap="round"/>
+  </g>
+  <text x="44" y="26" font-family="ui-sans-serif, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="19" font-weight="600" letter-spacing="-0.5" fill="#e6e9ee">guillotine</text>
+  <text x="150" y="26" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="17" font-weight="600" fill="#4da6ff">mini</text>
+</svg>

--- a/docs/public/logo-light.svg
+++ b/docs/public/logo-light.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 40" width="240" height="40" role="img" aria-label="Guillotine Mini">
+  <g>
+    <rect x="0" y="4" width="32" height="32" rx="7" fill="#0085ff"/>
+    <path d="M8 10.5v19M24 10.5v19" stroke="#ffffff" stroke-opacity="0.55" stroke-width="2" stroke-linecap="round"/>
+    <path d="M8 13h16l-4 7H8z" fill="#ffffff"/>
+    <path d="M8 24h16" stroke="#ffffff" stroke-width="2" stroke-linecap="round"/>
+  </g>
+  <text x="44" y="26" font-family="ui-sans-serif, -apple-system, 'Segoe UI', Helvetica, Arial, sans-serif" font-size="19" font-weight="600" letter-spacing="-0.5" fill="#101828">guillotine</text>
+  <text x="150" y="26" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="17" font-weight="600" fill="#0085ff">mini</text>
+</svg>

--- a/docs/src/components/OpcodeStepper.tsx
+++ b/docs/src/components/OpcodeStepper.tsx
@@ -1,0 +1,654 @@
+'use client'
+
+/**
+ * A dependency-free bytecode stepper.
+ *
+ * It interprets a useful subset of the EVM — arithmetic, comparison, bitwise,
+ * stack shuffling, memory, storage, jumps and the halting opcodes — with the
+ * Berlin-and-later gas schedule (including memory expansion and warm/cold
+ * storage access). It is a teaching aid for reading the real interpreter in
+ * `src/frame.zig`, not a second implementation of consensus.
+ */
+
+import { useCallback, useMemo, useState } from 'react'
+
+const MOD = 1n << 256n
+const MAX = MOD - 1n
+
+const asWord = (x: bigint) => ((x % MOD) + MOD) % MOD
+const toSigned = (x: bigint) => (x >= 1n << 255n ? x - MOD : x)
+const toUnsigned = (x: bigint) => asWord(x)
+
+type Op = {
+	name: string
+	/** Number of immediate bytes following the opcode (PUSH1..PUSH32). */
+	push?: number
+	/** Static gas cost. Dynamic components are added by the executor. */
+	gas: number
+	pops: number
+	pushes: number
+}
+
+const OPS: Record<number, Op> = {
+	0x00: { name: 'STOP', gas: 0, pops: 0, pushes: 0 },
+	0x01: { name: 'ADD', gas: 3, pops: 2, pushes: 1 },
+	0x02: { name: 'MUL', gas: 5, pops: 2, pushes: 1 },
+	0x03: { name: 'SUB', gas: 3, pops: 2, pushes: 1 },
+	0x04: { name: 'DIV', gas: 5, pops: 2, pushes: 1 },
+	0x05: { name: 'SDIV', gas: 5, pops: 2, pushes: 1 },
+	0x06: { name: 'MOD', gas: 5, pops: 2, pushes: 1 },
+	0x07: { name: 'SMOD', gas: 5, pops: 2, pushes: 1 },
+	0x08: { name: 'ADDMOD', gas: 8, pops: 3, pushes: 1 },
+	0x09: { name: 'MULMOD', gas: 8, pops: 3, pushes: 1 },
+	0x0a: { name: 'EXP', gas: 10, pops: 2, pushes: 1 },
+	0x10: { name: 'LT', gas: 3, pops: 2, pushes: 1 },
+	0x11: { name: 'GT', gas: 3, pops: 2, pushes: 1 },
+	0x12: { name: 'SLT', gas: 3, pops: 2, pushes: 1 },
+	0x13: { name: 'SGT', gas: 3, pops: 2, pushes: 1 },
+	0x14: { name: 'EQ', gas: 3, pops: 2, pushes: 1 },
+	0x15: { name: 'ISZERO', gas: 3, pops: 1, pushes: 1 },
+	0x16: { name: 'AND', gas: 3, pops: 2, pushes: 1 },
+	0x17: { name: 'OR', gas: 3, pops: 2, pushes: 1 },
+	0x18: { name: 'XOR', gas: 3, pops: 2, pushes: 1 },
+	0x19: { name: 'NOT', gas: 3, pops: 1, pushes: 1 },
+	0x1a: { name: 'BYTE', gas: 3, pops: 2, pushes: 1 },
+	0x1b: { name: 'SHL', gas: 3, pops: 2, pushes: 1 },
+	0x1c: { name: 'SHR', gas: 3, pops: 2, pushes: 1 },
+	0x50: { name: 'POP', gas: 2, pops: 1, pushes: 0 },
+	0x51: { name: 'MLOAD', gas: 3, pops: 1, pushes: 1 },
+	0x52: { name: 'MSTORE', gas: 3, pops: 2, pushes: 0 },
+	0x53: { name: 'MSTORE8', gas: 3, pops: 2, pushes: 0 },
+	0x54: { name: 'SLOAD', gas: 0, pops: 1, pushes: 1 },
+	0x55: { name: 'SSTORE', gas: 0, pops: 2, pushes: 0 },
+	0x56: { name: 'JUMP', gas: 8, pops: 1, pushes: 0 },
+	0x57: { name: 'JUMPI', gas: 10, pops: 2, pushes: 0 },
+	0x58: { name: 'PC', gas: 2, pops: 0, pushes: 1 },
+	0x59: { name: 'MSIZE', gas: 2, pops: 0, pushes: 1 },
+	0x5a: { name: 'GAS', gas: 2, pops: 0, pushes: 1 },
+	0x5b: { name: 'JUMPDEST', gas: 1, pops: 0, pushes: 0 },
+	0xf3: { name: 'RETURN', gas: 0, pops: 2, pushes: 0 },
+	0xfd: { name: 'REVERT', gas: 0, pops: 2, pushes: 0 },
+	0xfe: { name: 'INVALID', gas: 0, pops: 0, pushes: 0 },
+}
+
+// PUSH0..PUSH32, DUP1..DUP16, SWAP1..SWAP16 are regular enough to generate.
+OPS[0x5f] = { name: 'PUSH0', push: 0, gas: 2, pops: 0, pushes: 1 }
+for (let n = 1; n <= 32; n++)
+	OPS[0x5f + n] = { name: `PUSH${n}`, push: n, gas: 3, pops: 0, pushes: 1 }
+for (let n = 1; n <= 16; n++)
+	OPS[0x7f + n] = { name: `DUP${n}`, gas: 3, pops: n, pushes: n + 1 }
+for (let n = 1; n <= 16; n++)
+	OPS[0x8f + n] = { name: `SWAP${n}`, gas: 3, pops: n + 1, pushes: n + 1 }
+
+type Instruction = {
+	pc: number
+	opcode: number
+	name: string
+	arg?: bigint
+	size: number
+}
+
+export function disassemble(code: Uint8Array): Instruction[] {
+	const out: Instruction[] = []
+	let pc = 0
+	while (pc < code.length) {
+		const opcode = code[pc] as number
+		const op = OPS[opcode]
+		if (!op) {
+			out.push({ pc, opcode, name: `INVALID (0x${opcode.toString(16).padStart(2, '0')})`, size: 1 })
+			pc += 1
+			continue
+		}
+		const n = op.push ?? 0
+		let arg: bigint | undefined
+		if (n > 0) {
+			let v = 0n
+			for (let i = 0; i < n; i++) v = (v << 8n) | BigInt(code[pc + 1 + i] ?? 0)
+			arg = v
+		}
+		out.push({ pc, opcode, name: op.name, arg, size: 1 + n })
+		pc += 1 + n
+	}
+	return out
+}
+
+type State = {
+	pc: number
+	stack: bigint[]
+	memory: Uint8Array
+	storage: Map<string, bigint>
+	warmSlots: Set<string>
+	gasLeft: number
+	gasUsed: number
+	halted: false | 'stop' | 'return' | 'revert' | 'error'
+	message?: string
+	returnData?: Uint8Array
+	lastGas?: number
+	lastNote?: string
+}
+
+export function initialState(gasLimit: number): State {
+	return {
+		pc: 0,
+		stack: [],
+		memory: new Uint8Array(0),
+		storage: new Map(),
+		warmSlots: new Set(),
+		gasLeft: gasLimit,
+		gasUsed: 0,
+		halted: false,
+	}
+}
+
+const memoryCost = (words: number) => 3 * words + Math.floor((words * words) / 512)
+
+/** Grow `memory` so `[offset, offset+size)` is addressable; return the gas delta. */
+function expand(state: { memory: Uint8Array }, offset: number, size: number) {
+	if (size === 0) return 0
+	const needed = offset + size
+	if (needed <= state.memory.length) return 0
+	const oldWords = Math.ceil(state.memory.length / 32)
+	const newWords = Math.ceil(needed / 32)
+	const next = new Uint8Array(newWords * 32)
+	next.set(state.memory)
+	state.memory = next
+	return memoryCost(newWords) - memoryCost(oldWords)
+}
+
+function readWord(mem: Uint8Array, offset: number): bigint {
+	let v = 0n
+	for (let i = 0; i < 32; i++) v = (v << 8n) | BigInt(mem[offset + i] ?? 0)
+	return v
+}
+
+function writeWord(mem: Uint8Array, offset: number, value: bigint) {
+	for (let i = 31; i >= 0; i--) {
+		mem[offset + i] = Number(value & 0xffn)
+		value >>= 8n
+	}
+}
+
+/** Valid JUMPDESTs, excluding bytes that are PUSH immediates. */
+export function jumpdests(code: Uint8Array): Set<number> {
+	const set = new Set<number>()
+	let pc = 0
+	while (pc < code.length) {
+		const opcode = code[pc] as number
+		if (opcode === 0x5b) set.add(pc)
+		const n = OPS[opcode]?.push ?? 0
+		pc += 1 + n
+	}
+	return set
+}
+
+/** Execute exactly one instruction, returning the next state. Never mutates. */
+export function step(code: Uint8Array, prev: State, dests: Set<number>): State {
+	const s: State = {
+		...prev,
+		stack: [...prev.stack],
+		memory: prev.memory.slice(),
+		storage: new Map(prev.storage),
+		warmSlots: new Set(prev.warmSlots),
+		lastGas: undefined,
+		lastNote: undefined,
+		message: undefined,
+	}
+	if (s.halted) return prev
+	if (s.pc >= code.length) {
+		s.halted = 'stop'
+		s.message = 'Ran off the end of the code — implicit STOP.'
+		return s
+	}
+
+	const opcode = code[s.pc] as number
+	const op = OPS[opcode]
+	if (!op || op.name === 'INVALID') {
+		s.halted = 'error'
+		s.message = `Undefined opcode 0x${opcode.toString(16).padStart(2, '0')} — consumes all remaining gas.`
+		s.gasUsed += s.gasLeft
+		s.gasLeft = 0
+		return s
+	}
+	if (s.stack.length < op.pops) {
+		s.halted = 'error'
+		s.message = `Stack underflow: ${op.name} needs ${op.pops} item(s), stack has ${s.stack.length}.`
+		s.gasUsed += s.gasLeft
+		s.gasLeft = 0
+		return s
+	}
+
+	let gas = op.gas
+	let note = ''
+	const pop = () => s.stack.pop() as bigint
+	const push = (v: bigint) => {
+		if (s.stack.length >= 1024) throw new Error('stack overflow (1024 items)')
+		s.stack.push(asWord(v))
+	}
+	let nextPc = s.pc + 1 + (op.push ?? 0)
+
+	try {
+		switch (op.name) {
+			case 'STOP':
+				s.halted = 'stop'
+				note = 'Halts successfully with empty return data.'
+				break
+			case 'ADD': push(pop() + pop()); break
+			case 'MUL': push(pop() * pop()); break
+			case 'SUB': { const a = pop(), b = pop(); push(a - b); break }
+			case 'DIV': { const a = pop(), b = pop(); push(b === 0n ? 0n : a / b); break }
+			case 'SDIV': {
+				const a = toSigned(pop()), b = toSigned(pop())
+				push(b === 0n ? 0n : toUnsigned(a / b))
+				break
+			}
+			case 'MOD': { const a = pop(), b = pop(); push(b === 0n ? 0n : a % b); break }
+			case 'SMOD': {
+				const a = toSigned(pop()), b = toSigned(pop())
+				push(b === 0n ? 0n : toUnsigned(a % b))
+				break
+			}
+			case 'ADDMOD': { const a = pop(), b = pop(), n = pop(); push(n === 0n ? 0n : (a + b) % n); break }
+			case 'MULMOD': { const a = pop(), b = pop(), n = pop(); push(n === 0n ? 0n : (a * b) % n); break }
+			case 'EXP': {
+				const base = pop(), exp = pop()
+				const bytes = exp === 0n ? 0 : Math.ceil(exp.toString(16).length / 2)
+				gas += 50 * bytes
+				note = `Dynamic gas: 50 × ${bytes} exponent byte(s).`
+				let r = 1n, b = base % MOD, e = exp
+				while (e > 0n) {
+					if (e & 1n) r = (r * b) % MOD
+					b = (b * b) % MOD
+					e >>= 1n
+				}
+				push(r)
+				break
+			}
+			case 'LT': { const a = pop(), b = pop(); push(a < b ? 1n : 0n); break }
+			case 'GT': { const a = pop(), b = pop(); push(a > b ? 1n : 0n); break }
+			case 'SLT': { const a = toSigned(pop()), b = toSigned(pop()); push(a < b ? 1n : 0n); break }
+			case 'SGT': { const a = toSigned(pop()), b = toSigned(pop()); push(a > b ? 1n : 0n); break }
+			case 'EQ': { const a = pop(), b = pop(); push(a === b ? 1n : 0n); break }
+			case 'ISZERO': push(pop() === 0n ? 1n : 0n); break
+			case 'AND': push(pop() & pop()); break
+			case 'OR': push(pop() | pop()); break
+			case 'XOR': push(pop() ^ pop()); break
+			case 'NOT': push(MAX ^ pop()); break
+			case 'BYTE': { const i = pop(), x = pop(); push(i > 31n ? 0n : (x >> (8n * (31n - i))) & 0xffn); break }
+			case 'SHL': { const sh = pop(), v = pop(); push(sh > 255n ? 0n : v << sh); break }
+			case 'SHR': { const sh = pop(), v = pop(); push(sh > 255n ? 0n : v >> sh); break }
+			case 'POP': pop(); break
+			case 'MLOAD': {
+				const off = Number(pop())
+				gas += expand(s, off, 32)
+				push(readWord(s.memory, off))
+				note = 'Reads 32 bytes; memory expansion is charged quadratically.'
+				break
+			}
+			case 'MSTORE': {
+				const off = Number(pop()), val = pop()
+				gas += expand(s, off, 32)
+				writeWord(s.memory, off, val)
+				note = 'Writes 32 bytes at the offset, growing memory in 32-byte words.'
+				break
+			}
+			case 'MSTORE8': {
+				const off = Number(pop()), val = pop()
+				gas += expand(s, off, 1)
+				s.memory[off] = Number(val & 0xffn)
+				break
+			}
+			case 'SLOAD': {
+				const key = pop().toString()
+				const warm = s.warmSlots.has(key)
+				gas += warm ? 100 : 2100
+				s.warmSlots.add(key)
+				push(s.storage.get(key) ?? 0n)
+				note = warm ? 'Warm slot: 100 gas (EIP-2929).' : 'Cold slot: 2100 gas (EIP-2929).'
+				break
+			}
+			case 'SSTORE': {
+				const key = pop().toString()
+				const val = pop()
+				const warm = s.warmSlots.has(key)
+				if (!warm) gas += 2100
+				s.warmSlots.add(key)
+				const current = s.storage.get(key) ?? 0n
+				if (current === val) {
+					gas += 100
+					note = 'No-op write: 100 gas.'
+				} else if (current === 0n) {
+					gas += 20000
+					note = 'Zero → non-zero: 20000 gas (a new storage slot).'
+				} else {
+					gas += 2900
+					note = 'Non-zero → different value: 2900 gas.'
+				}
+				if (!warm) note += ' Plus a 2100 cold-slot surcharge.'
+				s.storage.set(key, val)
+				break
+			}
+			case 'JUMP': {
+				const dest = Number(pop())
+				if (!dests.has(dest)) throw new Error(`invalid jump destination ${dest} (not a JUMPDEST)`)
+				nextPc = dest
+				note = 'Jumps only to a JUMPDEST — checked before the jump is taken.'
+				break
+			}
+			case 'JUMPI': {
+				const dest = Number(pop()), cond = pop()
+				if (cond !== 0n) {
+					if (!dests.has(dest)) throw new Error(`invalid jump destination ${dest} (not a JUMPDEST)`)
+					nextPc = dest
+					note = 'Condition is non-zero — branch taken.'
+				} else {
+					note = 'Condition is zero — falls through.'
+				}
+				break
+			}
+			case 'PC': push(BigInt(s.pc)); break
+			case 'MSIZE': push(BigInt(s.memory.length)); break
+			case 'GAS': push(BigInt(Math.max(s.gasLeft - gas, 0))); break
+			case 'JUMPDEST': note = 'A no-op marker: the only legal target of a jump.'; break
+			case 'RETURN':
+			case 'REVERT': {
+				const off = Number(pop()), size = Number(pop())
+				gas += expand(s, off, size)
+				s.returnData = s.memory.slice(off, off + size)
+				s.halted = op.name === 'RETURN' ? 'return' : 'revert'
+				note =
+					op.name === 'RETURN'
+						? 'Halts successfully, returning a memory slice.'
+						: 'Halts, reverting state changes and refunding the remaining gas.'
+				break
+			}
+			default: {
+				if (op.name.startsWith('PUSH')) {
+					const n = op.push ?? 0
+					let v = 0n
+					for (let i = 0; i < n; i++) v = (v << 8n) | BigInt(code[s.pc + 1 + i] ?? 0)
+					push(v)
+				} else if (op.name.startsWith('DUP')) {
+					const n = Number(op.name.slice(3))
+					push(s.stack[s.stack.length - n] as bigint)
+				} else if (op.name.startsWith('SWAP')) {
+					const n = Number(op.name.slice(4))
+					const top = s.stack.length - 1
+					const other = top - n
+					const tmp = s.stack[top] as bigint
+					s.stack[top] = s.stack[other] as bigint
+					s.stack[other] = tmp
+				} else {
+					throw new Error(`${op.name} is not implemented in this explorer`)
+				}
+			}
+		}
+	} catch (err) {
+		s.halted = 'error'
+		s.message = err instanceof Error ? err.message : String(err)
+		s.gasUsed += s.gasLeft
+		s.gasLeft = 0
+		return s
+	}
+
+	if (gas > s.gasLeft) {
+		s.halted = 'error'
+		s.message = `Out of gas: ${op.name} costs ${gas}, only ${s.gasLeft} left.`
+		s.gasUsed += s.gasLeft
+		s.gasLeft = 0
+		return s
+	}
+
+	s.gasLeft -= gas
+	s.gasUsed += gas
+	s.lastGas = gas
+	s.lastNote = note
+	if (!s.halted) s.pc = nextPc
+	return s
+}
+
+export const EXAMPLES = [
+	{
+		id: 'return-42',
+		label: 'Return 42',
+		code: '602a60005260206000f3',
+		blurb:
+			'The smallest interesting program: store 42 in memory, then return those 32 bytes. This is the sample on the front page.',
+	},
+	{
+		id: 'arith',
+		label: 'Arithmetic + stack',
+		code: '600a60030260059003600052 60206000f3'.replace(/ /g, ''),
+		blurb: 'MUL, then SWAP1 + SUB to subtract in the other direction: 3 × 10 − 5 = 25 (0x19).',
+	},
+	{
+		id: 'loop',
+		label: 'Loop (sum 1..5)',
+		code: '600060055b801560155780910190600190036004565b5060005260206000f3',
+		blurb:
+			'A JUMPDEST-guarded countdown that accumulates 5+4+3+2+1 = 15 (0xf). JUMPI branches out once the counter hits zero.',
+	},
+	{
+		id: 'storage',
+		label: 'Cold vs warm storage',
+		code: '600160005560026000556000546000526 0206000f3'.replace(/ /g, ''),
+		blurb:
+			'Two SSTOREs to the same slot: the first pays the cold surcharge plus 20000 for zero → non-zero, the second only 2900.',
+	},
+	{
+		id: 'revert',
+		label: 'Revert',
+		code: '60426000526020600 0fd'.replace(/ /g, ''),
+		blurb: 'REVERT halts with return data but undoes state changes.',
+	},
+	{
+		id: 'oog',
+		label: 'Out of gas',
+		code: '600160005560026001556003600255600460035560056004556006600555',
+		blurb: 'Five cold storage writes against a small gas limit — set gas low and watch it die.',
+	},
+] as const
+
+function parseCode(input: string): { code?: Uint8Array; error?: string } {
+	const hex = input.trim().replace(/^0x/i, '').replace(/\s+/g, '')
+	if (hex.length === 0) return { code: new Uint8Array(0) }
+	if (!/^[0-9a-fA-F]*$/.test(hex)) return { error: 'Bytecode must be hex digits only.' }
+	if (hex.length % 2 !== 0) return { error: 'Bytecode must have an even number of hex digits.' }
+	const code = new Uint8Array(hex.length / 2)
+	for (let i = 0; i < code.length; i++) code[i] = Number.parseInt(hex.slice(i * 2, i * 2 + 2), 16)
+	return { code }
+}
+
+const hexWord = (v: bigint) => `0x${v.toString(16)}`
+
+const toHex = (bytes: Uint8Array) =>
+	`0x${Array.from(bytes)
+		.map((b) => b.toString(16).padStart(2, '0'))
+		.join('')}`
+
+export function OpcodeStepper() {
+	const [source, setSource] = useState<string>(EXAMPLES[0].code)
+	const [gasLimit, setGasLimit] = useState<number>(100_000)
+	const [exampleId, setExampleId] = useState<string>(EXAMPLES[0].id)
+	const [state, setState] = useState<State>(() => initialState(100_000))
+
+	const parsed = useMemo(() => parseCode(source), [source])
+	const code = parsed.code ?? new Uint8Array(0)
+	const instructions = useMemo(() => disassemble(code), [code])
+	const dests = useMemo(() => jumpdests(code), [code])
+	const example = EXAMPLES.find((e) => e.id === exampleId)
+
+	const reset = useCallback((limit = gasLimit) => setState(initialState(limit)), [gasLimit])
+
+	const doStep = useCallback(() => {
+		setState((prev) => step(code, prev, dests))
+	}, [code, dests])
+
+	const runToEnd = useCallback(() => {
+		setState((prev) => {
+			let cur = prev
+			// Bounded so a mistyped loop cannot hang the page.
+			for (let i = 0; i < 10_000 && !cur.halted; i++) cur = step(code, cur, dests)
+			if (!cur.halted) return { ...cur, halted: 'error', message: 'Stopped after 10,000 steps.' }
+			return cur
+		})
+	}, [code, dests])
+
+	const onPickExample = (id: string) => {
+		const next = EXAMPLES.find((e) => e.id === id)
+		if (!next) return
+		setExampleId(id)
+		setSource(next.code)
+		setState(initialState(gasLimit))
+	}
+
+	const onGasChange = (value: string) => {
+		const n = Number.parseInt(value, 10)
+		const limit = Number.isFinite(n) && n > 0 ? n : 0
+		setGasLimit(limit)
+		setState(initialState(limit))
+	}
+
+	const halted = state.halted
+
+	return (
+		<div className="gm-stepper">
+			<div className="gm-stepper-bar">
+				<select
+					aria-label="Example program"
+					value={exampleId}
+					onChange={(e) => onPickExample(e.target.value)}
+				>
+					{EXAMPLES.map((e) => (
+						<option key={e.id} value={e.id}>
+							{e.label}
+						</option>
+					))}
+				</select>
+				<input
+					aria-label="Bytecode (hex)"
+					spellCheck={false}
+					value={source}
+					onChange={(e) => {
+						setSource(e.target.value)
+						setState(initialState(gasLimit))
+					}}
+				/>
+				<input
+					aria-label="Gas limit"
+					style={{ flex: '0 0 7rem' }}
+					value={String(gasLimit)}
+					onChange={(e) => onGasChange(e.target.value)}
+				/>
+				<button type="button" className="gm-btn gm-btn--primary" onClick={doStep} disabled={!!halted}>
+					Step
+				</button>
+				<button type="button" className="gm-btn" onClick={runToEnd} disabled={!!halted}>
+					Run
+				</button>
+				<button type="button" className="gm-btn" onClick={() => reset()}>
+					Reset
+				</button>
+			</div>
+
+			<div className="gm-stepper-body">
+				<div className="gm-pane">
+					<p className="gm-pane-title">Bytecode</p>
+					{parsed.error ? (
+						<p className="gm-note gm-note--error">{parsed.error}</p>
+					) : instructions.length === 0 ? (
+						<p className="gm-empty">Paste some hex bytecode to disassemble it.</p>
+					) : (
+						<div className="gm-code">
+							{instructions.map((ins) => (
+								<div
+									key={ins.pc}
+									className="gm-row"
+									data-current={!halted && ins.pc === state.pc}
+									data-done={ins.pc < state.pc}
+								>
+									<span className="gm-pc">{ins.pc.toString().padStart(3, '0')}</span>
+									<span className="gm-mnemonic">{ins.name}</span>
+									<span className="gm-arg">{ins.arg === undefined ? '' : hexWord(ins.arg)}</span>
+									<span className="gm-gas">{OPS[ins.opcode]?.gas ? `${OPS[ins.opcode]?.gas}g` : ''}</span>
+								</div>
+							))}
+						</div>
+					)}
+				</div>
+
+				<div className="gm-pane">
+					<div className="gm-meters">
+						<div className="gm-meter">
+							<span className="gm-meter-label">Gas used</span>
+							<span className="gm-meter-value">{state.gasUsed.toLocaleString()}</span>
+						</div>
+						<div className="gm-meter">
+							<span className="gm-meter-label">Gas left</span>
+							<span className="gm-meter-value">{state.gasLeft.toLocaleString()}</span>
+						</div>
+						<div className="gm-meter">
+							<span className="gm-meter-label">Memory</span>
+							<span className="gm-meter-value">{state.memory.length}b</span>
+						</div>
+					</div>
+
+					<p className="gm-pane-title">Stack (top first)</p>
+					<div className="gm-stack">
+						{state.stack.length === 0 ? (
+							<p className="gm-empty">empty</p>
+						) : (
+							state.stack.map((v, i) => (
+								<div
+									key={`${i}-${v}`}
+									className="gm-stack-item"
+									data-top={i === state.stack.length - 1}
+								>
+									<span className="gm-stack-index">{state.stack.length - 1 - i}</span>
+									<span className="gm-stack-value">{hexWord(v)}</span>
+								</div>
+							))
+						)}
+					</div>
+
+					{state.storage.size > 0 && (
+						<>
+							<p className="gm-pane-title" style={{ marginTop: '0.75rem' }}>
+								Storage
+							</p>
+							<div className="gm-stack" style={{ flexDirection: 'column' }}>
+								{[...state.storage.entries()].map(([k, v]) => (
+									<div key={k} className="gm-stack-item">
+										<span className="gm-stack-index">{hexWord(BigInt(k))}</span>
+										<span className="gm-stack-value">{hexWord(v)}</span>
+									</div>
+								))}
+							</div>
+						</>
+					)}
+
+					{(state.lastNote || state.message) && (
+						<p className={`gm-note${halted === 'error' || halted === 'revert' ? ' gm-note--error' : ''}`}>
+							{state.message ?? state.lastNote}
+							{state.lastGas !== undefined && !state.message ? ` (${state.lastGas} gas)` : ''}
+						</p>
+					)}
+
+					{halted && (
+						<p className="gm-return">
+							halted: {halted}
+							{state.returnData ? ` · return data ${toHex(state.returnData)}` : ''}
+						</p>
+					)}
+				</div>
+			</div>
+
+			{example && (
+				<p className="gm-note" style={{ margin: 0, borderLeft: 'none', background: 'transparent' }}>
+					{example.blurb}
+				</p>
+			)}
+		</div>
+	)
+}
+
+export default OpcodeStepper

--- a/docs/src/pages/_root.css
+++ b/docs/src/pages/_root.css
@@ -1,0 +1,548 @@
+/*
+ * Shared tevm.sh design tokens.
+ *
+ * These mirror the token set used by the sibling docs sites (bundler.tevm.sh,
+ * contract.tevm.sh, …) so the family reads as one system. Keep the names and
+ * values in sync when the shared theme moves — everything below is expressed
+ * with `light-dark()` so both color schemes are correct by construction.
+ */
+:root {
+	--tevm-accent: light-dark(#0085ff, #4da6ff);
+	--tevm-accent-strong: light-dark(#0066cc, #2e8ce6);
+	--tevm-accent-soft: light-dark(#0085ff14, #4da6ff1f);
+	--tevm-bg-raised: light-dark(#ffffff, #14161a);
+	--tevm-bg-sunken: light-dark(#f5f6f8, #0c0e11);
+	--tevm-border: light-dark(#1018281f, #ffffff1a);
+	--tevm-border-strong: light-dark(#10182833, #ffffff2e);
+	--tevm-text: light-dark(#101828, #e6e9ee);
+	--tevm-text-muted: light-dark(#475467, #98a2b3);
+	--tevm-terminal-bg: light-dark(#0b0e14, #07090d);
+	--tevm-terminal-border: light-dark(#10182840, #ffffff1f);
+	--tevm-term-prompt: #4da6ff;
+	--tevm-term-flag: #7dd3fc;
+	--tevm-term-string: #fdb022;
+	--tevm-term-success: #32d583;
+	--tevm-term-error: #f97066;
+	--tevm-term-dim: #8b93a3;
+	--tevm-term-text: #c7cfdb;
+	--tevm-mono: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, Monaco, Consolas,
+		'Liberation Mono', 'Courier New', monospace;
+	--tevm-radius: 10px;
+	--tevm-radius-sm: 6px;
+}
+
+/* ---------------------------------------------------------------- hero --- */
+
+.tevm-hero {
+	position: relative;
+	overflow: hidden;
+	margin: -1rem 0 2.5rem;
+	padding: 3.5rem 2rem 3rem;
+	border: 1px solid var(--tevm-border);
+	border-radius: calc(var(--tevm-radius) + 6px);
+	background:
+		radial-gradient(60rem 24rem at 85% -10%, var(--tevm-accent-soft), transparent 60%),
+		radial-gradient(40rem 20rem at -10% 110%, var(--tevm-accent-soft), transparent 60%),
+		var(--tevm-bg-raised);
+}
+
+.tevm-hero::before {
+	content: '';
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	opacity: 0.35;
+	background-image:
+		linear-gradient(var(--tevm-border) 1px, transparent 1px),
+		linear-gradient(90deg, var(--tevm-border) 1px, transparent 1px);
+	background-size: 44px 44px;
+	mask-image: radial-gradient(50rem 26rem at 50% 0, #000, transparent 75%);
+	-webkit-mask-image: radial-gradient(50rem 26rem at 50% 0, #000, transparent 75%);
+}
+
+.tevm-hero > * {
+	position: relative;
+}
+
+.tevm-hero-eyebrow {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.25rem 0.75rem;
+	border: 1px solid var(--tevm-border-strong);
+	border-radius: 999px;
+	background: var(--tevm-bg-raised);
+	color: var(--tevm-accent);
+	font-family: var(--tevm-mono);
+	font-size: 0.78rem;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+}
+
+.tevm-hero h1 {
+	margin: 1rem 0 0.5rem;
+	padding: 0;
+	border: none;
+	font-size: clamp(2.2rem, 5vw, 3.4rem);
+	line-height: 1.05;
+	letter-spacing: -0.03em;
+}
+
+.tevm-hero h1 .tevm-hero-accent {
+	color: var(--tevm-accent);
+}
+
+.tevm-hero-sub {
+	max-width: 42rem;
+	margin: 0 0 1.75rem;
+	color: var(--tevm-text-muted);
+	font-size: 1.05rem;
+}
+
+.tevm-hero-actions {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.75rem;
+}
+
+.tevm-button {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.55rem 1.1rem;
+	border: 1px solid var(--tevm-border-strong);
+	border-radius: var(--tevm-radius-sm);
+	background: var(--tevm-bg-raised);
+	color: var(--tevm-text);
+	font-size: 0.9rem;
+	font-weight: 600;
+	text-decoration: none;
+	transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+.tevm-button:hover {
+	border-color: var(--tevm-accent);
+	transform: translateY(-1px);
+}
+
+.tevm-button:active {
+	transform: translateY(0);
+}
+
+.tevm-button--primary {
+	border-color: transparent;
+	background: var(--tevm-accent);
+	color: #fff;
+}
+
+.tevm-button--primary:hover {
+	background: var(--tevm-accent-strong);
+}
+
+/* ------------------------------------------------------------- install --- */
+
+.tevm-install {
+	margin: 1.75rem 0 0;
+	max-width: 46rem;
+	border: 1px solid var(--tevm-terminal-border);
+	border-radius: var(--tevm-radius);
+	background: var(--tevm-terminal-bg);
+	overflow: hidden;
+}
+
+.tevm-install-code {
+	display: flex;
+	align-items: center;
+	gap: 0.75rem;
+	padding: 0.85rem 1rem;
+	font-family: var(--tevm-mono);
+	font-size: 0.85rem;
+	color: var(--tevm-term-text);
+	overflow-x: auto;
+}
+
+.tevm-install-code .tevm-prompt {
+	color: var(--tevm-term-prompt);
+	user-select: none;
+}
+
+.tevm-install-code .tevm-flag {
+	color: var(--tevm-term-flag);
+}
+
+/* ---------------------------------------------------------- code window --- */
+
+.tevm-codewin {
+	margin: 2rem 0;
+	border: 1px solid var(--tevm-terminal-border);
+	border-radius: var(--tevm-radius);
+	background: var(--tevm-terminal-bg);
+	overflow: hidden;
+}
+
+.tevm-codewin-titlebar {
+	display: flex;
+	align-items: center;
+	gap: 0.45rem;
+	padding: 0.6rem 0.85rem;
+	border-bottom: 1px solid var(--tevm-terminal-border);
+}
+
+.tevm-codewin-dot {
+	width: 10px;
+	height: 10px;
+	border-radius: 999px;
+	background: #4b5563;
+}
+
+.tevm-codewin-dot:first-child {
+	background: #f97066;
+}
+.tevm-codewin-dot:nth-child(2) {
+	background: #fdb022;
+}
+.tevm-codewin-dot:nth-child(3) {
+	background: #32d583;
+}
+
+.tevm-codewin-title {
+	margin-left: 0.5rem;
+	color: var(--tevm-term-dim);
+	font-family: var(--tevm-mono);
+	font-size: 0.75rem;
+}
+
+/* ------------------------------------------------------------ features --- */
+
+.tevm-features {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+	gap: 1rem;
+	margin: 2rem 0;
+}
+
+.tevm-feature {
+	padding: 1.1rem 1.2rem;
+	border: 1px solid var(--tevm-border);
+	border-radius: var(--tevm-radius);
+	background: var(--tevm-bg-raised);
+}
+
+.tevm-feature h3 {
+	margin: 0 0 0.35rem;
+	border: none;
+	padding: 0;
+	font-size: 0.95rem;
+}
+
+.tevm-feature p {
+	margin: 0;
+	color: var(--tevm-text-muted);
+	font-size: 0.88rem;
+	line-height: 1.5;
+}
+
+/* --------------------------------------------------------- family grid --- */
+
+.tevm-sites {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
+	gap: 0.6rem;
+	margin: 1.5rem 0 2rem;
+}
+
+.tevm-site-card {
+	display: block;
+	padding: 0.7rem 0.85rem;
+	border: 1px solid var(--tevm-border);
+	border-radius: var(--tevm-radius-sm);
+	background: var(--tevm-bg-raised);
+	text-decoration: none;
+	transition: border-color 0.15s ease, transform 0.15s ease;
+}
+
+.tevm-site-card:hover {
+	border-color: var(--tevm-accent);
+	transform: translateY(-1px);
+}
+
+.tevm-site-card-name {
+	display: block;
+	color: var(--tevm-text);
+	font-size: 0.9rem;
+	font-weight: 600;
+}
+
+.tevm-site-card-host {
+	display: block;
+	color: var(--tevm-text-muted);
+	font-family: var(--tevm-mono);
+	font-size: 0.75rem;
+}
+
+.tevm-site-card[data-current='true'] {
+	border-color: var(--tevm-accent);
+	background: var(--tevm-accent-soft);
+}
+
+/* ------------------------------------------------------ opcode stepper --- */
+
+.gm-stepper {
+	margin: 1.5rem 0 2rem;
+	border: 1px solid var(--tevm-border);
+	border-radius: var(--tevm-radius);
+	background: var(--tevm-bg-raised);
+	overflow: hidden;
+}
+
+.gm-stepper-bar {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.7rem 0.85rem;
+	border-bottom: 1px solid var(--tevm-border);
+	background: var(--tevm-bg-sunken);
+}
+
+.gm-stepper-bar select,
+.gm-stepper-bar input {
+	padding: 0.35rem 0.5rem;
+	border: 1px solid var(--tevm-border-strong);
+	border-radius: var(--tevm-radius-sm);
+	background: var(--tevm-bg-raised);
+	color: var(--tevm-text);
+	font-family: var(--tevm-mono);
+	font-size: 0.8rem;
+}
+
+.gm-stepper-bar input {
+	flex: 1 1 16rem;
+	min-width: 10rem;
+}
+
+.gm-btn {
+	padding: 0.35rem 0.7rem;
+	border: 1px solid var(--tevm-border-strong);
+	border-radius: var(--tevm-radius-sm);
+	background: var(--tevm-bg-raised);
+	color: var(--tevm-text);
+	font-size: 0.8rem;
+	font-weight: 600;
+	cursor: pointer;
+}
+
+.gm-btn:hover:not(:disabled) {
+	border-color: var(--tevm-accent);
+}
+
+.gm-btn:disabled {
+	opacity: 0.45;
+	cursor: not-allowed;
+}
+
+.gm-btn--primary {
+	border-color: transparent;
+	background: var(--tevm-accent);
+	color: #fff;
+}
+
+.gm-stepper-body {
+	display: grid;
+	grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+	gap: 0;
+}
+
+@media (max-width: 900px) {
+	.gm-stepper-body {
+		grid-template-columns: minmax(0, 1fr);
+	}
+}
+
+.gm-pane {
+	padding: 0.85rem 1rem;
+	min-width: 0;
+}
+
+.gm-pane + .gm-pane {
+	border-left: 1px solid var(--tevm-border);
+}
+
+@media (max-width: 900px) {
+	.gm-pane + .gm-pane {
+		border-left: none;
+		border-top: 1px solid var(--tevm-border);
+	}
+}
+
+.gm-pane-title {
+	margin: 0 0 0.5rem;
+	color: var(--tevm-text-muted);
+	font-family: var(--tevm-mono);
+	font-size: 0.72rem;
+	letter-spacing: 0.08em;
+	text-transform: uppercase;
+}
+
+.gm-code {
+	max-height: 20rem;
+	overflow-y: auto;
+	font-family: var(--tevm-mono);
+	font-size: 0.8rem;
+}
+
+.gm-row {
+	display: grid;
+	grid-template-columns: 4rem 5rem 1fr auto;
+	gap: 0.5rem;
+	padding: 0.2rem 0.4rem;
+	border-radius: var(--tevm-radius-sm);
+	color: var(--tevm-text);
+	white-space: nowrap;
+}
+
+.gm-row[data-current='true'] {
+	background: var(--tevm-accent-soft);
+	outline: 1px solid var(--tevm-accent);
+}
+
+.gm-row[data-done='true'] {
+	opacity: 0.55;
+}
+
+.gm-pc {
+	color: var(--tevm-text-muted);
+}
+
+.gm-mnemonic {
+	color: var(--tevm-accent);
+	font-weight: 600;
+}
+
+.gm-arg {
+	color: var(--tevm-text-muted);
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.gm-gas {
+	color: var(--tevm-text-muted);
+	font-size: 0.72rem;
+}
+
+.gm-stack {
+	display: flex;
+	flex-direction: column-reverse;
+	gap: 0.25rem;
+	min-height: 4rem;
+	font-family: var(--tevm-mono);
+	font-size: 0.78rem;
+}
+
+.gm-stack-item {
+	display: flex;
+	gap: 0.5rem;
+	padding: 0.25rem 0.45rem;
+	border: 1px solid var(--tevm-border);
+	border-radius: var(--tevm-radius-sm);
+	background: var(--tevm-bg-sunken);
+	overflow: hidden;
+}
+
+.gm-stack-item[data-top='true'] {
+	border-color: var(--tevm-accent);
+}
+
+.gm-stack-index {
+	color: var(--tevm-text-muted);
+}
+
+.gm-stack-value {
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+.gm-empty {
+	color: var(--tevm-text-muted);
+	font-family: var(--tevm-mono);
+	font-size: 0.78rem;
+}
+
+.gm-meters {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	margin-bottom: 0.75rem;
+}
+
+.gm-meter {
+	flex: 1 1 7rem;
+	padding: 0.45rem 0.6rem;
+	border: 1px solid var(--tevm-border);
+	border-radius: var(--tevm-radius-sm);
+	background: var(--tevm-bg-sunken);
+}
+
+.gm-meter-label {
+	display: block;
+	color: var(--tevm-text-muted);
+	font-size: 0.68rem;
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+}
+
+.gm-meter-value {
+	display: block;
+	color: var(--tevm-text);
+	font-family: var(--tevm-mono);
+	font-size: 0.95rem;
+	font-weight: 600;
+}
+
+.gm-note {
+	margin-top: 0.75rem;
+	padding: 0.5rem 0.65rem;
+	border-left: 2px solid var(--tevm-accent);
+	background: var(--tevm-accent-soft);
+	color: var(--tevm-text);
+	font-size: 0.8rem;
+	line-height: 1.5;
+}
+
+.gm-note--error {
+	border-left-color: var(--tevm-term-error);
+	background: light-dark(#f9706614, #f9706622);
+}
+
+.gm-note code {
+	font-family: var(--tevm-mono);
+}
+
+.gm-return {
+	margin-top: 0.5rem;
+	word-break: break-all;
+	font-family: var(--tevm-mono);
+	font-size: 0.75rem;
+	color: var(--tevm-text-muted);
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.tevm-button,
+	.tevm-site-card {
+		transition: none;
+	}
+	.tevm-button:hover,
+	.tevm-site-card:hover {
+		transform: none;
+	}
+}
+
+.tevm-hero-code {
+	padding: 0.1em 0.35em;
+	border: 1px solid var(--tevm-border);
+	border-radius: var(--tevm-radius-sm);
+	background: var(--tevm-bg-sunken);
+	font-family: var(--tevm-mono);
+	font-size: 0.88em;
+}

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -4,11 +4,33 @@ title: Guillotine Mini — a small, readable EVM in Zig
 description: A small, embeddable Ethereum Virtual Machine written in Zig — spec-first, hardfork-aware, and easy to read.
 ---
 
-# Guillotine Mini
+<div className="tevm-hero">
+  <span className="tevm-hero-eyebrow">guillotine · mini</span>
 
-A small, embeddable **Ethereum Virtual Machine written in Zig**. One `Evm` type,
-one `call()` entry point, hardforks from Frontier through Osaka, precompiles,
-transaction-scoped state, and EIP-3155 tracing.
+  <h1>A readable EVM,<br /><span className="tevm-hero-accent">written in Zig</span></h1>
+
+  <div className="tevm-hero-sub">
+    A small, embeddable Ethereum Virtual Machine. One <span className="tevm-hero-code">Evm</span> type, one{' '}
+    <span className="tevm-hero-code">call()</span> entry point, hardforks from Frontier through Osaka,
+    precompiles, transaction-scoped state, and EIP-3155 tracing.
+  </div>
+
+  <div className="tevm-hero-actions">
+    <a className="tevm-button tevm-button--primary" href="/getting-started">Get started →</a>
+    <a className="tevm-button" href="/opcode-explorer">Step through bytecode</a>
+    <a className="tevm-button" href="https://github.com/evmts/guillotine-mini">GitHub</a>
+  </div>
+
+  <div className="tevm-install">
+    <div className="tevm-install-code">
+      <span className="tevm-prompt">$</span>
+      <span>
+        zig fetch <span className="tevm-flag">--save</span>{' '}
+        {'https://github.com/evmts/guillotine-mini/archive/refs/tags/v0.1.0.tar.gz'}
+      </span>
+    </div>
+  </div>
+</div>
 
 ```zig
 const Evm = guillotine.Evm(guillotine.EvmConfig{});
@@ -81,3 +103,24 @@ into. It is pre-1.0: public APIs may change between minor releases.
   Rust artifact in the Voltaire dependency. See
   [Building from Source](/native-build#webassembly).
 
+
+## The rest of the family
+
+Guillotine Mini is one site in the Tevm docs family. Each of these is a live,
+separately versioned project:
+
+<div className="tevm-sites">
+  <a className="tevm-site-card" href="https://tevm.sh"><span className="tevm-site-card-name">Tevm</span><span className="tevm-site-card-host">tevm.sh</span></a>
+  <a className="tevm-site-card" href="https://contract.tevm.sh"><span className="tevm-site-card-name">Contract</span><span className="tevm-site-card-host">contract.tevm.sh</span></a>
+  <a className="tevm-site-card" href="https://logger.tevm.sh"><span className="tevm-site-card-name">Logger</span><span className="tevm-site-card-host">logger.tevm.sh</span></a>
+  <a className="tevm-site-card" href="https://test.tevm.sh"><span className="tevm-site-card-name">Test</span><span className="tevm-site-card-host">test.tevm.sh</span></a>
+  <a className="tevm-site-card" href="https://bundler.tevm.sh"><span className="tevm-site-card-name">Bundler</span><span className="tevm-site-card-host">bundler.tevm.sh</span></a>
+  <a className="tevm-site-card" href="https://cli.tevm.sh"><span className="tevm-site-card-name">CLI</span><span className="tevm-site-card-host">cli.tevm.sh</span></a>
+  <a className="tevm-site-card" href="https://ethers.tevm.sh"><span className="tevm-site-card-name">Ethers</span><span className="tevm-site-card-host">ethers.tevm.sh</span></a>
+  <a className="tevm-site-card" href="https://mud.tevm.sh"><span className="tevm-site-card-name">MUD</span><span className="tevm-site-card-host">mud.tevm.sh</span></a>
+  <a className="tevm-site-card" href="https://examples.tevm.sh"><span className="tevm-site-card-name">Examples</span><span className="tevm-site-card-host">examples.tevm.sh</span></a>
+  <a className="tevm-site-card" href="https://voltaire.tevm.sh"><span className="tevm-site-card-name">Voltaire</span><span className="tevm-site-card-host">voltaire.tevm.sh</span></a>
+  <a className="tevm-site-card" href="https://guillotine.tevm.sh"><span className="tevm-site-card-name">Guillotine</span><span className="tevm-site-card-host">guillotine.tevm.sh</span></a>
+  <a className="tevm-site-card" data-current="true" href="https://mini.tevm.sh"><span className="tevm-site-card-name">Mini</span><span className="tevm-site-card-host">mini.tevm.sh</span></a>
+  <a className="tevm-site-card" href="https://zevm.tevm.sh"><span className="tevm-site-card-name">ZEVM</span><span className="tevm-site-card-host">zevm.tevm.sh</span></a>
+</div>

--- a/docs/src/pages/opcode-explorer.mdx
+++ b/docs/src/pages/opcode-explorer.mdx
@@ -1,0 +1,40 @@
+---
+title: Opcode & gas explorer
+description: Step through EVM bytecode one instruction at a time and watch the stack, memory, storage and gas move.
+---
+
+import { OpcodeStepper } from '../components/OpcodeStepper'
+
+# Opcode & gas explorer
+
+Guillotine Mini's interpreter is a loop over one byte at a time: decode, check
+the stack, charge gas, mutate the frame. This page runs that same loop in your
+browser so you can watch it happen.
+
+Pick an example or paste your own hex, then **Step** through it. The highlighted
+row is the program counter; the right pane is the frame the interpreter is
+mutating.
+
+<OpcodeStepper />
+
+## What it models
+
+- **Stack, memory and storage** — every value is a 256-bit word, memory grows in
+  32-byte words, storage is a slot map scoped to this run.
+- **Gas, including the dynamic parts** — memory expansion is charged
+  quadratically, `EXP` pays per exponent byte, and `SLOAD`/`SSTORE` pay the
+  EIP-2929 cold-access surcharge on first touch.
+- **Jump validation** — `JUMP` and `JUMPI` only accept a `JUMPDEST` that is a
+  real instruction, not a byte inside a `PUSH` immediate.
+
+## What it does not
+
+This is a reading aid, not a second EVM. It implements arithmetic, comparison,
+bitwise, stack, memory, storage, jump and halting opcodes — no hashing, no
+environment opcodes, no calls or creates, and no gas refunds. For any of those,
+the answer lives in [`src/frame.zig`](https://github.com/evmts/guillotine-mini/blob/main/src/frame.zig)
+and is exercised by the fixtures described in
+[Testing and Debugging](/guides/testing).
+
+To run the real thing over the same bytecode, see
+[Executing Bytecode](/guides/executing-bytecode).

--- a/docs/vocs.config.ts
+++ b/docs/vocs.config.ts
@@ -4,6 +4,8 @@ import { defineConfig } from 'vocs/config'
 
 const tevmSites = [
 	{ text: 'Tevm', link: 'https://tevm.sh' },
+	{ text: 'Contract', link: 'https://contract.tevm.sh' },
+	{ text: 'Logger', link: 'https://logger.tevm.sh' },
 	{ text: 'Test', link: 'https://test.tevm.sh' },
 	{ text: 'Bundler', link: 'https://bundler.tevm.sh' },
 	{ text: 'CLI', link: 'https://cli.tevm.sh' },


### PR DESCRIPTION
Visual/UI layer for **mini.tevm.sh**. Content is not touched — this branch is stacked on the docs-content branch `prod/guillotine-mini-readiness` (PR #39), which is where the site actually lives; it is not on `main` yet, so this PR targets that branch.

## Theme
`docs/src/pages/_root.css` ports the shared `--tevm-*` token set that bundler.tevm.sh and contract.tevm.sh already ship (accent, raised/sunken surfaces, borders, text, terminal palette, mono stack, radii), written with `light-dark()` so **both schemes are correct by construction** rather than by a `.dark` override. Verified computed values in a real browser:

| | hero background | h1 | accent |
|---|---|---|---|
| light | `rgb(255,255,255)` | `oklch(0.29 0 0)` | `rgb(0,133,255)` |
| dark | `rgb(20,22,26)` | `oklch(0.933 0 0)` | `rgb(77,166,255)` |

## Logo / favicon
`vocs.config.ts` already referenced `/logo-light.svg`, `/logo-dark.svg` and `/favicon.svg` — **all three 404 in production today** (`curl https://mini.tevm.sh/logo-light.svg` → 404). Added them: a guillotine-frame mark in the family accent plus a `guillotine` + mono `mini` wordmark, with dark/light variants.

## Hero
Headline, sub, a copy-paste install line (`zig fetch --save …`), and three actions. The existing intro prose and the Zig code sample below it are unchanged.

## Interactive component: `/opcode-explorer`
One self-contained, dependency-free React component (`docs/src/components/OpcodeStepper.tsx`) — no new packages. It disassembles hex bytecode and steps it one instruction at a time, showing the program counter, stack, memory size, storage and gas.

It models the parts that make the EVM's shape legible:
- arithmetic / comparison / bitwise / stack / memory / storage / jump / halt opcodes
- **dynamic gas**: quadratic memory expansion, per-exponent-byte `EXP`, EIP-2929 cold (2100) vs warm (100) storage access, and the 20000/2900/100 `SSTORE` cases
- **jump validation** against real `JUMPDEST`s, excluding bytes inside `PUSH` immediates

Six worked examples ship with it. Their results were checked against the interpreter headlessly:

```
return-42    halted=return gasUsed=18    ret=42
arith        halted=return gasUsed=35    ret=25
loop         halted=return gasUsed=304   ret=15
storage      halted=return gasUsed=25130 ret=2
revert       halted=revert gasUsed=18    ret=66
oog          halted=error  gasUsed=30000 Out of gas: SSTORE costs 22100, only 7888 left.
```

The page says plainly what it does *not* do (no hashing, environment opcodes, calls/creates or refunds) and points at `src/frame.zig` for the real thing.

## Cross-repo navigation
Added **Contract** and **Logger** to the Ecosystem menu (they were missing) and a link grid on the landing page covering all 13 family sites. Every one was verified live:

```
tevm.sh 308  contract 200  logger 200  test 200  bundler 200  cli 200  ethers 200
mud 200  examples 200  voltaire 200  guillotine 200  mini 200  zevm 200
```

## Verification

```
$ npm run build
✓ built in 8.42s
[ssg] processing static generation...
[prune] removed static-only 23 chunk(s) and 0 asset(s) from server bundle
✓ 49 files generated in 913ms
```

Then driven with Playwright at 1280×900 in both color schemes (`vocs dev`), stepping and running the explorer:

```
light | after 1 step stack top: 0x2a | gas used: 18 | halted: return · return data 0x…2a
light | errors: none
dark  | after 1 step stack top: 0x2a | gas used: 18 | halted: return · return data 0x…2a
dark  | errors: none
```

Zero console/page errors in both themes. One hydration mismatch found during this pass (MDX wraps multi-line JSX text in a `<p>`, so a `<p className="tevm-hero-sub">` nested `<p>` inside `<p>`) was fixed before the final run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)